### PR TITLE
fix: Update SMTP server domain to river-flow-smtp-server.vercel.app

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -67,7 +67,7 @@ app.jwt.refresh-token-expiration-ms=604800000
 # SMTP SERVER CONFIGURATION (Proxy)
 # ==============================================================================
 # SMTP Proxy Server URL (Deployed on Vercel)
-app.smtp.server.url=https://river-flow-smtp-server-t3zk.vercel.app
+app.smtp.server.url=https://river-flow-smtp-server.vercel.app
 app.smtp.server.api-key=riverflow-smtp-secure-key-2024
 
 # Logging


### PR DESCRIPTION
- Change from river-flow-smtp-server-t3zk.vercel.app to official domain
- Update application.properties with correct Vercel domain