### PR TITLE
feat: Update to generated API key for SMTP server

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -68,7 +68,8 @@ app.jwt.refresh-token-expiration-ms=604800000
 # ==============================================================================
 # SMTP Proxy Server URL (Deployed on Vercel)
 app.smtp.server.url=https://river-flow-smtp-server.vercel.app
-app.smtp.server.api-key=riverflow-smtp-secure-key-2024
+# Generated API Key (Production Server - Main RiverFlow backend)
+app.smtp.server.api-key=rfsk_JOHo3vQB4rJrvWPMUUr0O3ko0iJMefcSLM6yFsTbSJIzvniC
 
 # Logging
 logging.level.root=INFO


### PR DESCRIPTION
- Replace default API key with generated key from Redis Cloud
- API Key ID: 1762793060749
- Key Name: Production Server
- Description: Main RiverFlow backend
- Generated via API key management system

This key is stored in Redis Cloud and can be managed via /api/keys endpoints with Master API key.