### PR TITLE
fix: Update frontend and backend URLs to production domains

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -45,10 +45,14 @@ spring.mail.properties.mail.smtp.ssl.trust=smtp.gmail.com
 # APPLICATION CONFIGURATION
 # ==============================================================================
 # Domain frontend (dùng để hiển thị UI)
-app.frontend.url=http://localhost:3000
+# Production: https://river-flow-client.vercel.app
+# Local: http://localhost:3000
+app.frontend.url=https://river-flow-client.vercel.app
 
 # Backend base URL (dùng để tạo link xác thực backend xử lý)
-app.backend.url=http://localhost:8080/api
+# Production: https://riverflow-server.onrender.com/api
+# Local: http://localhost:8080/api
+app.backend.url=https://riverflow-server.onrender.com/api
 
 # Thời hạn token xác minh (phút)
 app.verification.expire-minutes=15


### PR DESCRIPTION
- Change app.frontend.url from localhost to https://river-flow-client.vercel.app
- Change app.backend.url from localhost to https://riverflow-server.onrender.com/api
- Fixes 'Invalid frontend URL' validation error in SMTP server
- Frontend URL must be valid HTTPS URL for email links to work correctly