### PR TITLE
fix: Update application-prod.properties with production URLs

### DIFF
--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -55,10 +55,12 @@ spring.mail.properties.mail.smtp.writetimeout=5000
 # APPLICATION CONFIGURATION
 # ==============================================================================
 # Frontend URL (Vercel deployment)
-app.frontend.url=${APP_FRONTEND_URL:http://localhost:3000}
+# Default to production URL, can be overridden by APP_FRONTEND_URL env var
+app.frontend.url=${APP_FRONTEND_URL:https://river-flow-client.vercel.app}
 
 # Backend URL (Render deployment)
-app.backend.url=${APP_BACKEND_URL:http://localhost:8080/api}
+# Default to production URL, can be overridden by APP_BACKEND_URL env var
+app.backend.url=${APP_BACKEND_URL:https://riverflow-server.onrender.com/api}
 
 # Token expiration
 app.verification.expire-minutes=15
@@ -73,7 +75,16 @@ app.jwt.refresh-token-expiration-ms=604800000
 # ==============================================================================
 # CORS CONFIGURATION
 # ==============================================================================
-app.cors.allowed-origins=${APP_FRONTEND_URL:http://localhost:3000}
+app.cors.allowed-origins=${APP_FRONTEND_URL:https://river-flow-client.vercel.app}
+
+# ==============================================================================
+# SMTP SERVER CONFIGURATION (Proxy)
+# ==============================================================================
+# SMTP Proxy Server URL (Deployed on Vercel)
+# Default to production URL, can be overridden by APP_SMTP_SERVER_URL env var
+app.smtp.server.url=${APP_SMTP_SERVER_URL:https://river-flow-smtp-server.vercel.app}
+# Generated API Key (can be overridden by APP_SMTP_SERVER_API_KEY env var)
+app.smtp.server.api-key=${APP_SMTP_SERVER_API_KEY:rfsk_JOHo3vQB4rJrvWPMUUr0O3ko0iJMefcSLM6yFsTbSJIzvniC}
 
 # ==============================================================================
 # LOGGING CONFIGURATION


### PR DESCRIPTION
Critical fix:
- Change app.frontend.url default from localhost to https://river-flow-client.vercel.app
- Change app.backend.url default from localhost to https://riverflow-server.onrender.com/api
- Update CORS allowed origins to production URL
- Add SMTP server configuration with production URL and generated API key

This fixes the issue where Render.com was using localhost URLs because application-prod.properties had localhost as defaults.

Render.com likely uses 'prod' profile or environment variables override the main application.properties file.