### PR TITLE
fix: disable FileStorageService and JPA open-in-view to eliminate sta…

### DIFF
--- a/src/main/java/com/riverflow/service/user/FileStorageService.java
+++ b/src/main/java/com/riverflow/service/user/FileStorageService.java
@@ -3,7 +3,6 @@ package com.riverflow.service.user;
 import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -16,8 +15,12 @@ import java.util.UUID;
 
 /**
  * Service for handling file storage operations
+ * 
+ * @deprecated Avatar storage has been moved to database (BLOB).
+ * This service is kept for backward compatibility but is no longer used.
+ * The AvatarService handles all avatar operations now.
  */
-@Service
+// @Service  // DISABLED: Avatar storage moved to database (AvatarService)
 @Slf4j
 public class FileStorageService {
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -19,6 +19,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=false
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.format_sql=false
+spring.jpa.open-in-view=false
 
 # Connection Pool Configuration
 spring.datasource.hikari.maximum-pool-size=10

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,7 @@ spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.open-in-view=false
 
 # ==============================================================================
 # MONGODB CONFIGURATION


### PR DESCRIPTION
…rtup warnings

- Comment @Service annotation on FileStorageService (no longer used since avatar storage moved to database)
- Remove unused org.springframework.stereotype.Service import
- Disable spring.jpa.open-in-view in both application.properties and application-prod.properties
- Add deprecation notice to FileStorageService class documentation

Resolves warnings from startup logs when avatars are now stored in MySQL BLOB