### PR TITLE
fix: apply layout after optimize operations to prevent tangled nodes

### DIFF
--- a/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
@@ -302,7 +302,14 @@ public class AiMindmapServiceImpl implements AiMindmapService {
         } else {
             }
 
-        // 5. Save changes
+        // 5. Apply layout to properly position all nodes
+        // Use structure type from AI decision, or fall back to request, or default to mindmap
+        String structureType = decision.structureType() != null 
+                ? decision.structureType() 
+                : (request.getStructureType() != null ? request.getStructureType() : "mindmap");
+        layoutEngine.applyLayout(structureType, mindmap.getNodes(), mindmap.getEdges());
+
+        // 6. Save changes
         UpdateMindmapRequest updateReq = UpdateMindmapRequest.builder()
                 .nodes(mindmap.getNodes())
                 .edges(mindmap.getEdges())


### PR DESCRIPTION
- Add layoutEngine.applyLayout() call after executeOperations() in optimize()
- Use structure type from AI decision or request fallback
- Ensures all nodes have proper spacing with positionAbsolute
- Fixes issue where optimize/add nodes always appeared at (0,0) or overlapping

Related to: chore/improve-spacing-generate