### PR TITLE
fix: pass structureType to AI prompt in optimize endpoint

### DIFF
--- a/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
@@ -343,7 +343,8 @@ public class AiMindmapServiceImpl implements AiMindmapService {
                 mindmap.getNodes(),
                 mindmap.getEdges(),
                 lang,
-                request.getHints());
+                request.getHints(),
+                request.getStructureType());
 
         // Use streaming to send AI's natural language response to client
         String response = callGeminiStream(payload, String.valueOf(mindmap.getId()));

--- a/src/main/java/com/riverflow/service/mindmap/ai/GeminiPromptBuilder.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/GeminiPromptBuilder.java
@@ -20,7 +20,8 @@ public class GeminiPromptBuilder {
                         List<Map<String, Object>> nodes,
                         List<Map<String, Object>> edges,
                         String language,
-                        List<String> hints) {
+                        List<String> hints,
+                        String structureType) {
                 StringBuilder system = new StringBuilder();
                 system.append("Bạn là trợ lý AI thông minh cho mindmap. Nhiệm vụ:\\n");
                 system.append("1. FIRST: Giải thích bằng ngôn ngữ tự nhiên (").append(language)
@@ -77,6 +78,12 @@ public class GeminiPromptBuilder {
                         user.append("\\n");
                 }
                 user.append("\\n");
+
+                // Add structure type requirement if specified
+                if (StringUtils.hasText(structureType) && !"mindmap".equalsIgnoreCase(structureType)) {
+                        user.append("STRUCTURE TYPE REQUIRED: ").append(structureType).append("\\n");
+                        user.append("You MUST return this structureType in your JSON response.\\n\\n");
+                }
 
                 if (hints != null && !hints.isEmpty()) {
                         user.append("Yêu cầu của người dùng:\\n");


### PR DESCRIPTION
- Add structureType parameter to buildClassifyActionPrompt()
- Update optimize prompt to tell AI which structure type user wants
- Pass request.getStructureType() from askAiForDecision()
- AI now knows to return the correct structureType in decision

Fixes issue where AI ignored user's structure type preference in optimize/generate operations