### PR TITLE
fix: remove conflicting handle logic to ensure edges are visible

### DIFF
--- a/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/AiMindmapServiceImpl.java
@@ -240,11 +240,7 @@ public class AiMindmapServiceImpl implements AiMindmapService {
                 edge.put("type", edgeTypes[typeIndex % edgeTypes.length]);
                 edge.put("animated", typeIndex % 2 == 0);
 
-                // Vary handles for diversity
-                if (typeIndex % 3 == 0) {
-                    edge.put("sourceHandle", handles[(typeIndex / 2) % handles.length]);
-                    edge.put("targetHandle", handles[(typeIndex / 3) % handles.length]);
-                }
+                // Don't set handles here - let calculateEdgeHandles() do it based on positions
 
                 // Add markers occasionally
                 if (typeIndex % 4 == 0) {


### PR DESCRIPTION
- Removed old handle assignment using ['a','b','c','d'] handles
- Let calculateEdgeHandles() set proper handles for ALL edges
- Ensures all edges have sourceHandle and targetHandle set
- Fixes issue where edges were not visible in UI

The old logic only set handles 33% of the time with invalid handle names, causing edges to not render properly.