### PR TITLE
fix: Add null safety checks for Gemini response in thinking mode

### DIFF
--- a/src/main/java/com/riverflow/service/mindmap/ai/AiResponseParser.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/AiResponseParser.java
@@ -76,6 +76,13 @@ public class AiResponseParser {
      */
     public ActionList parseActionList(String json) {
         ActionList actionList = new ActionList();
+        
+        // Add null/empty check first
+        if (json == null || json.trim().isEmpty()) {
+            System.err.println("[parseActionList] Received null or empty JSON string");
+            return actionList;
+        }
+        
         try {
             JsonNode root = objectMapper.readTree(json);
             JsonNode actionsNode = root.get("actions");
@@ -93,8 +100,7 @@ public class AiResponseParser {
                     }
                 }
             } else {
-                System.err.println("[parseActionList] No 'actions' array found in JSON. Root keys: " + 
-                    (root != null ? root.fieldNames().toString() : "null"));
+                System.err.println("[parseActionList] 'actions' array not found in JSON");
             }
         } catch (Exception e) {
             System.err.println("[parseActionList] Failed to parse JSON: " + e.getMessage());

--- a/src/main/java/com/riverflow/service/mindmap/ai/AiThinkingModeServiceImpl.java
+++ b/src/main/java/com/riverflow/service/mindmap/ai/AiThinkingModeServiceImpl.java
@@ -63,9 +63,25 @@ public class AiThinkingModeServiceImpl implements AiThinkingModeService {
             String otmzJson = objectMapper.writeValueAsString(otmz);
             Map<String, Object> payload = promptBuilder.buildActionListPrompt(otmzJson, language);
             String text = callGeminiStream(payload, mindmapId);
+            
+            // Check if Gemini response is null or empty
+            if (text == null || text.trim().isEmpty()) {
+                System.err.println("[plan] Gemini returned null or empty response");
+                return new ActionList();
+            }
+            
             String json = promptBuilder.ensureJson(text);
+            
+            // Check if JSON extraction failed
+            if (json == null || json.trim().isEmpty()) {
+                System.err.println("[plan] ensureJson returned null or empty. Raw response: " + text);
+                return new ActionList();
+            }
+            
             return responseParser.parseActionList(json);
         } catch (Exception e) {
+            System.err.println("[plan] Exception: " + e.getMessage());
+            e.printStackTrace();
             return new ActionList();
         }
     }


### PR DESCRIPTION
- Added null/empty check in plan() before calling ensureJson
- Added null/empty check in parseActionList() to prevent IllegalArgumentException
- Added detailed error logging for debugging
- Returns empty ActionList gracefully when Gemini response is null/empty